### PR TITLE
Forcing the package user to redirect to avoid refresh workflows

### DIFF
--- a/src/Discord/HandlesDiscordWebhooksBeingCreated.php
+++ b/src/Discord/HandlesDiscordWebhooksBeingCreated.php
@@ -2,7 +2,7 @@
 
 namespace LaravelRestcord\Discord;
 
-use Illuminate\Http\Response;
+use Illuminate\Http\RedirectResponse;
 
 trait HandlesDiscordWebhooksBeingCreated
 {
@@ -12,5 +12,5 @@ trait HandlesDiscordWebhooksBeingCreated
      * what happens next.  It's a good place to save the webhook details and present
      * the user with a new screen or redirect them.
      */
-    abstract public function webhookCreated(Webhook $webhook) : Response;
+    abstract public function webhookCreated(Webhook $webhook) : RedirectResponse;
 }

--- a/src/Http/WebhookCallback.php
+++ b/src/Http/WebhookCallback.php
@@ -6,8 +6,8 @@ use GuzzleHttp\Client;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Routing\UrlGenerator;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use LaravelRestcord\Discord;
 use LaravelRestcord\Discord\HandlesDiscordWebhooksBeingCreated;
 use LaravelRestcord\Discord\Webhook;
@@ -20,7 +20,7 @@ class WebhookCallback
         Repository $config,
         Client $client,
         UrlGenerator $urlGenerator
-    ) : Response {
+    ) : RedirectResponse {
         $response = $client->post('https://discordapp.com/api/oauth2/token', [
             'headers' => [
                 'Accept' => 'application/json',

--- a/tests/Http/WebhookCallbackTest.php
+++ b/tests/Http/WebhookCallbackTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Psr7\Response;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Routing\UrlGenerator;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use LaravelRestcord\Discord\HandlesDiscordWebhooksBeingCreated;
 use LaravelRestcord\Discord\Webhook;
@@ -83,7 +84,7 @@ class WebhookCallbackTest extends TestCase
 
         $webhookCreatedHandler = uniqid();
         $this->config->shouldReceive('get')->with('laravel-restcord.webhook-created-handler')->andReturn($webhookCreatedHandler);
-        $controllerResponse = Mockery::mock(\Illuminate\Http\Response::class);
+        $controllerResponse = Mockery::mock(RedirectResponse::class);
         $handlesWebhookCreated = Mockery::mock(HandlesDiscordWebhooksBeingCreated::class);
         $handlesWebhookCreated->shouldReceive('webhookCreated')->with(Mockery::on(function ($arg) {
             return Webhook::class == get_class($arg);


### PR DESCRIPTION
Webhook implementations now require a redirect.  This prevents the developer from creating a workflow where the page can be refreshed to re-create the webhook.