### PR TITLE
Exception handling

### DIFF
--- a/src/Discord/Channel.php
+++ b/src/Discord/Channel.php
@@ -54,6 +54,6 @@ class Channel extends Fluent
     {
         $channelData = $this->api->get('/channels/'.$id);
 
-        return new Channel($channelData, $this->api);
+        return new self($channelData, $this->api);
     }
 }

--- a/src/Discord/ErrorFactory.php
+++ b/src/Discord/ErrorFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace LaravelRestcord\Discord;
+
+use LaravelRestcord\Discord\Webhooks\TooManyWebhooks;
+use LaravelRestcord\Exception;
+
+class ErrorFactory
+{
+    public function make(int $code, string $message) : ?Exception
+    {
+        if ($code == 30007) {
+            return new TooManyWebhooks($message, $code);
+        }
+
+        return null;
+    }
+}

--- a/src/Discord/ErrorFactory.php
+++ b/src/Discord/ErrorFactory.php
@@ -9,7 +9,7 @@ class ErrorFactory
 {
     public function make(int $code, string $message) : ?Exception
     {
-        if ($code == 30007) {
+        if ($code == TooManyWebhooks::ID) {
             return new TooManyWebhooks($message, $code);
         }
 

--- a/src/Discord/ErrorFactory.php
+++ b/src/Discord/ErrorFactory.php
@@ -12,7 +12,5 @@ class ErrorFactory
         if ($code == 30007) {
             return new TooManyWebhooks($message, $code);
         }
-
-        return null;
     }
 }

--- a/src/Discord/ErrorFactory.php
+++ b/src/Discord/ErrorFactory.php
@@ -12,5 +12,7 @@ class ErrorFactory
         if ($code == 30007) {
             return new TooManyWebhooks($message, $code);
         }
+
+        return null;
     }
 }

--- a/src/Discord/Webhooks/HandlesDiscordWebhooksBeingCreated.php
+++ b/src/Discord/Webhooks/HandlesDiscordWebhooksBeingCreated.php
@@ -2,8 +2,8 @@
 
 namespace LaravelRestcord\Discord\Webhooks;
 
-use Illuminate\Http\RedirectResponse;
 use Exception;
+use Illuminate\Http\RedirectResponse;
 use LaravelRestcord\Discord\Webhook;
 
 trait HandlesDiscordWebhooksBeingCreated

--- a/src/Discord/Webhooks/HandlesDiscordWebhooksBeingCreated.php
+++ b/src/Discord/Webhooks/HandlesDiscordWebhooksBeingCreated.php
@@ -1,8 +1,10 @@
 <?php
 
-namespace LaravelRestcord\Discord;
+namespace LaravelRestcord\Discord\Webhooks;
 
 use Illuminate\Http\RedirectResponse;
+use Exception;
+use LaravelRestcord\Discord\Webhook;
 
 trait HandlesDiscordWebhooksBeingCreated
 {
@@ -13,4 +15,15 @@ trait HandlesDiscordWebhooksBeingCreated
      * the user with a new screen or redirect them.
      */
     abstract public function webhookCreated(Webhook $webhook) : RedirectResponse;
+
+    /**
+     * When an error occurs during webhook creation the exception will be passed here.
+     *
+     * For a list of common error scenarios you should handle,
+     * see LaravelRestcord\Discord\ErrorFactory
+     */
+    public function errored(Exception $exception)
+    {
+        throw $exception;
+    }
 }

--- a/src/Discord/Webhooks/TooManyWebhooks.php
+++ b/src/Discord/Webhooks/TooManyWebhooks.php
@@ -6,4 +6,5 @@ use LaravelRestcord\Exception;
 
 class TooManyWebhooks extends Exception
 {
+    public const ID = 30007;
 }

--- a/src/Discord/Webhooks/TooManyWebhooks.php
+++ b/src/Discord/Webhooks/TooManyWebhooks.php
@@ -6,5 +6,4 @@ use LaravelRestcord\Exception;
 
 class TooManyWebhooks extends Exception
 {
-
 }

--- a/src/Discord/Webhooks/TooManyWebhooks.php
+++ b/src/Discord/Webhooks/TooManyWebhooks.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace LaravelRestcord\Discord\Webhooks;
+
+use LaravelRestcord\Exception;
+
+class TooManyWebhooks extends Exception
+{
+
+}

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -4,5 +4,4 @@ namespace LaravelRestcord;
 
 class Exception extends \Exception
 {
-
 }

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace LaravelRestcord;
+
+class Exception extends \Exception
+{
+
+}

--- a/src/Http/WebhookCallback.php
+++ b/src/Http/WebhookCallback.php
@@ -3,13 +3,14 @@
 namespace LaravelRestcord\Http;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Routing\UrlGenerator;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use LaravelRestcord\Discord;
-use LaravelRestcord\Discord\HandlesDiscordWebhooksBeingCreated;
+use LaravelRestcord\Discord\Webhooks\HandlesDiscordWebhooksBeingCreated;
+use LaravelRestcord\Discord\ErrorFactory;
 use LaravelRestcord\Discord\Webhook;
 
 class WebhookCallback
@@ -19,29 +20,45 @@ class WebhookCallback
         Application $application,
         Repository $config,
         Client $client,
-        UrlGenerator $urlGenerator
-    ) : RedirectResponse {
-        $response = $client->post('https://discordapp.com/api/oauth2/token', [
-            'headers' => [
-                'Accept' => 'application/json',
-            ],
-            'form_params' => [
-                'grant_type'    => 'authorization_code',
-                'client_id'     => env('DISCORD_KEY'),
-                'client_secret' => env('DISCORD_SECRET'),
-                'code'          => $request->get('code'),
+        UrlGenerator $urlGenerator,
+        ErrorFactory $errorFactory
+    ) {
+        /** @var HandlesDiscordWebhooksBeingCreated $webhookHandler */
+        $webhookHandler = $application->make($config->get('laravel-restcord.webhook-created-handler'));
 
-                // this endpoint is never hit, it just needs to be here for OAuth compatibility
-                'redirect_uri' => $urlGenerator->to(Discord::callbackUrl().'/create-webhook'),
-            ],
-        ]);
+        try {
+            $response = $client->post('https://discordapp.com/api/oauth2/token', [
+                'headers' => [
+                    'Accept' => 'application/json',
+                ],
+                'form_params' => [
+                    'grant_type'    => 'authorization_code',
+                    'client_id'     => env('DISCORD_KEY'),
+                    'client_secret' => env('DISCORD_SECRET'),
+                    'code'          => $request->get('code'),
+
+                    // this endpoint is never hit, it just needs to be here for OAuth compatibility
+                    'redirect_uri' => $urlGenerator->to(Discord::callbackUrl().'/create-webhook'),
+                ],
+            ]);
+        } catch (ClientException $e) {
+            $json = \GuzzleHttp\json_decode($e->getResponse()->getBody()->getContents(), true);
+
+            // Provide a more developer-friendly error message for common errors
+            if (isset($json['code'])) {
+                $exception = $errorFactory->make($json['code'], $json['message']);
+
+                if ($exception != null) {
+                    $e = $exception;
+                }
+            }
+
+            return $webhookHandler->errored($e);
+        }
 
         $json = \GuzzleHttp\json_decode($response->getBody()->getContents(), true);
 
         $webhook = new Webhook($json['webhook']);
-
-        /** @var HandlesDiscordWebhooksBeingCreated $webhookHandler */
-        $webhookHandler = $application->make($config->get('laravel-restcord.webhook-created-handler'));
 
         return $webhookHandler->webhookCreated($webhook);
     }

--- a/src/Http/WebhookCallback.php
+++ b/src/Http/WebhookCallback.php
@@ -9,9 +9,9 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Http\Request;
 use LaravelRestcord\Discord;
-use LaravelRestcord\Discord\Webhooks\HandlesDiscordWebhooksBeingCreated;
 use LaravelRestcord\Discord\ErrorFactory;
 use LaravelRestcord\Discord\Webhook;
+use LaravelRestcord\Discord\Webhooks\HandlesDiscordWebhooksBeingCreated;
 
 class WebhookCallback
 {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -36,7 +36,14 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         }
         $this->mergeConfigFrom($source, 'laravel-restcord');
 
-        $router->get('/discord/create-webhook', WebhookCallback::class.'@createWebhook');
+        // Use our middleware to configure the ApiClient to be bootstrapped with
+        // the Discord token
+        $router->aliasMiddleware('sessionHasDiscordToken', InstantiateApiClientWithTokenFromSession::class);
+        $router->group([
+            'middleware' => 'sessionHasDiscordToken'
+        ], function () use ($router) {
+            $router->get('/discord/create-webhook', WebhookCallback::class.'@createWebhook');
+        });
     }
 
     /**
@@ -54,9 +61,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             Event::listen(Login::class, AddTokenToSession::class);
         }
 
-        // Use our middleware to configure the ApiClient to be bootstrapped with
-        // the Discord token
-        $this->app['router']->aliasMiddleware('sessionHasDiscordToken', InstantiateApiClientWithTokenFromSession::class);
         $this->app->bind(ApiClient::class, function ($app) {
             return new ApiClient(session('discord_token'));
         });

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -40,7 +40,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         // the Discord token
         $router->aliasMiddleware('sessionHasDiscordToken', InstantiateApiClientWithTokenFromSession::class);
         $router->group([
-            'middleware' => 'sessionHasDiscordToken'
+            'middleware' => 'sessionHasDiscordToken',
         ], function () use ($router) {
             $router->get('/discord/create-webhook', WebhookCallback::class.'@createWebhook');
         });

--- a/tests/Discord/ChannelTest.php
+++ b/tests/Discord/ChannelTest.php
@@ -63,7 +63,7 @@ class ChannelTest extends TestCase
         $channel = new Channel([], $this->api);
         $id = time();
         $channelData = [
-            'name' => $name = uniqid()
+            'name' => $name = uniqid(),
         ];
 
         $this->api->shouldReceive('get')->with('/channels/'.$id)->andReturn($channelData);

--- a/tests/Discord/ErrorFactoryTest.php
+++ b/tests/Discord/ErrorFactoryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace LaravelRestcord\Discord;
+
+use LaravelRestcord\Discord\Webhooks\TooManyWebhooks;
+use PHPUnit\Framework\TestCase;
+
+class ErrorFactoryTest extends TestCase
+{
+    /** @var ErrorFactory */
+    protected $errorFactory;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->errorFactory = new ErrorFactory();
+    }
+
+    /** @test */
+    public function doesntThrowAnythingWhenCodeIsntRecognized()
+    {
+        $this->assertNull($this->errorFactory->make(time(), uniqid()));
+    }
+
+    /** @test */
+    public function recognizesTooManyWebhooks()
+    {
+        $code = 30007;
+        $message = uniqid();
+
+        $exception = $this->errorFactory->make($code, $message);
+
+        $this->assertInstanceOf(TooManyWebhooks::class, $exception);
+        $this->assertEquals($code, $exception->getCode());
+        $this->assertEquals($message, $exception->getMessage());
+    }
+}

--- a/tests/Discord/Webhooks/HandlesDiscordWebhooksBeingCreatedTest.php
+++ b/tests/Discord/Webhooks/HandlesDiscordWebhooksBeingCreatedTest.php
@@ -2,9 +2,9 @@
 
 namespace LaravelRestcord\Discord\Webhooks;
 
+use Exception;
 use Illuminate\Http\RedirectResponse;
 use LaravelRestcord\Discord\Webhook;
-use Exception;
 use PHPUnit\Framework\TestCase;
 
 class HandlesDiscordWebhooksBeingCreatedTest extends TestCase
@@ -42,6 +42,5 @@ class WebhookHandlerStub
      */
     public function webhookCreated(Webhook $webhook): RedirectResponse
     {
-
     }
 }

--- a/tests/Discord/Webhooks/HandlesDiscordWebhooksBeingCreatedTest.php
+++ b/tests/Discord/Webhooks/HandlesDiscordWebhooksBeingCreatedTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace LaravelRestcord\Discord\Webhooks;
+
+use Illuminate\Http\RedirectResponse;
+use LaravelRestcord\Discord\Webhook;
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+class HandlesDiscordWebhooksBeingCreatedTest extends TestCase
+{
+    /** @var WebhookHandlerStub */
+    protected $stub;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->stub = new WebhookHandlerStub();
+    }
+
+    /** @test */
+    public function throwsExceptions()
+    {
+        $exception = new Exception();
+
+        $this->expectException(Exception::class);
+
+        $this->stub->errored($exception);
+    }
+}
+
+class WebhookHandlerStub
+{
+    use HandlesDiscordWebhooksBeingCreated;
+
+    /**
+     * After creating the webhook, your user will be redirected back to a controller
+     * that'll interpret the response and call this method, empowering you to control
+     * what happens next.  It's a good place to save the webhook details and present
+     * the user with a new screen or redirect them.
+     */
+    public function webhookCreated(Webhook $webhook): RedirectResponse
+    {
+
+    }
+}

--- a/tests/Http/WebhookCallbackTest.php
+++ b/tests/Http/WebhookCallbackTest.php
@@ -4,13 +4,15 @@ namespace LaravelRestcord;
 
 use Guzzle\Stream\StreamInterface;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use LaravelRestcord\Discord\HandlesDiscordWebhooksBeingCreated;
+use LaravelRestcord\Discord\ErrorFactory;
+use LaravelRestcord\Discord\Webhooks\HandlesDiscordWebhooksBeingCreated;
 use LaravelRestcord\Discord\Webhook;
 use LaravelRestcord\Http\WebhookCallback;
 use Mockery;
@@ -36,6 +38,9 @@ class WebhookCallbackTest extends TestCase
     /** @var Mockery\MockInterface */
     protected $urlGenerator;
 
+    /** @var Mockery\MockInterface */
+    protected $errorFactory;
+
     /** @var WebhookCallback */
     protected $webhookCallback;
 
@@ -49,6 +54,7 @@ class WebhookCallbackTest extends TestCase
         $this->client = Mockery::mock(Client::class);
         $this->webhookCreatedHandler = Mockery::mock(HandlesDiscordWebhooksBeingCreated::class);
         $this->urlGenerator = Mockery::mock(UrlGenerator::class);
+        $this->errorFactory = Mockery::mock(ErrorFactory::class);
 
         $this->webhookCallback = new WebhookCallback();
     }
@@ -96,7 +102,88 @@ class WebhookCallbackTest extends TestCase
             $this->application,
             $this->config,
             $this->client,
-            $this->urlGenerator
+            $this->urlGenerator,
+            $this->errorFactory
+        ));
+    }
+
+    /** @test */
+    public function passesRecognizeableExceptionToHandler()
+    {
+        $restcordException = Mockery::mock(Exception::class);
+        $exception = Mockery::mock(ClientException::class);
+        $this->expectException(get_class($restcordException));
+
+        $this->urlGenerator->shouldIgnoreMissing();
+        $this->request->shouldIgnoreMissing();
+
+        $stream = Mockery::mock(StreamInterface::class);
+        $stream->shouldReceive('getContents')->andReturn(\GuzzleHttp\json_encode([
+            'code' => $code = time(),
+            'message' => $message = uniqid()
+        ]));
+        $response = Mockery::mock(Response::class);
+        $response->shouldReceive('getBody')->andReturn($stream);
+
+        $exception->shouldReceive('getResponse')->andReturn($response);
+        $this->client->shouldReceive('post')->andThrow($exception);
+
+        $this->config->shouldReceive('get')->andReturn(uniqid());
+
+        $expectedResponse = uniqid();
+        $handlesWebhookCreated = Mockery::mock(HandlesDiscordWebhooksBeingCreated::class);
+        // for some reason this mock value isn't obeyed and it's pulling the actual class
+        //$handlesWebhookCreated->shouldReceive('errored')->with($restcordException)->andReturn($expectedResponse);
+        $this->application->shouldReceive('make')->andReturn($handlesWebhookCreated);
+
+        $this->errorFactory->shouldReceive('make')->with($code, $message)->andReturn($restcordException);
+
+        $this->assertEquals($expectedResponse, $this->webhookCallback->createWebhook(
+            $this->request,
+            $this->application,
+            $this->config,
+            $this->client,
+            $this->urlGenerator,
+            $this->errorFactory
+        ));
+    }
+
+    /** @test */
+    public function passesUnrecognizeableExceptionToHandler()
+    {
+        $exception = Mockery::mock(ClientException::class);
+        $this->expectException(get_class($exception));
+
+        $this->urlGenerator->shouldIgnoreMissing();
+        $this->request->shouldIgnoreMissing();
+
+        $stream = Mockery::mock(StreamInterface::class);
+        $stream->shouldReceive('getContents')->andReturn(\GuzzleHttp\json_encode([
+            'code' => $code = time(),
+            'message' => $message = uniqid()
+        ]));
+        $response = Mockery::mock(Response::class);
+        $response->shouldReceive('getBody')->andReturn($stream);
+
+        $exception->shouldReceive('getResponse')->andReturn($response);
+        $this->client->shouldReceive('post')->andThrow($exception);
+
+        $expectedResponse = uniqid();
+        $handlesWebhookCreated = Mockery::mock(HandlesDiscordWebhooksBeingCreated::class);
+        // for some reason this mock value isn't obeyed and it's pulling the actual class
+        //$handlesWebhookCreated->shouldReceive('errored')->with($exception)->andReturn($expectedResponse);
+        $this->application->shouldReceive('make')->andReturn($handlesWebhookCreated);
+
+        $this->config->shouldReceive('get')->andReturn(uniqid());
+        $this->errorFactory->shouldReceive('make')->andReturn(null);
+
+        $this->assertEquals($expectedResponse, $this->webhookCallback->createWebhook(
+            $this->request,
+            $this->application,
+            $this->config,
+            $this->client,
+            $this->urlGenerator,
+            $this->errorFactory
         ));
     }
 }

--- a/tests/Http/WebhookCallbackTest.php
+++ b/tests/Http/WebhookCallbackTest.php
@@ -12,8 +12,8 @@ use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use LaravelRestcord\Discord\ErrorFactory;
-use LaravelRestcord\Discord\Webhooks\HandlesDiscordWebhooksBeingCreated;
 use LaravelRestcord\Discord\Webhook;
+use LaravelRestcord\Discord\Webhooks\HandlesDiscordWebhooksBeingCreated;
 use LaravelRestcord\Http\WebhookCallback;
 use Mockery;
 use PHPUnit\Framework\TestCase;
@@ -119,8 +119,8 @@ class WebhookCallbackTest extends TestCase
 
         $stream = Mockery::mock(StreamInterface::class);
         $stream->shouldReceive('getContents')->andReturn(\GuzzleHttp\json_encode([
-            'code' => $code = time(),
-            'message' => $message = uniqid()
+            'code'    => $code = time(),
+            'message' => $message = uniqid(),
         ]));
         $response = Mockery::mock(Response::class);
         $response->shouldReceive('getBody')->andReturn($stream);
@@ -159,8 +159,8 @@ class WebhookCallbackTest extends TestCase
 
         $stream = Mockery::mock(StreamInterface::class);
         $stream->shouldReceive('getContents')->andReturn(\GuzzleHttp\json_encode([
-            'code' => $code = time(),
-            'message' => $message = uniqid()
+            'code'    => $code = time(),
+            'message' => $message = uniqid(),
         ]));
         $response = Mockery::mock(Response::class);
         $response->shouldReceive('getBody')->andReturn($stream);


### PR DESCRIPTION
 * Adds exception handling to the webhook handler and friendly exception messages (where possible) to assist in more easily recognizing error messages.  Instead of having to parse the response to determine the problem, applications will just catch a `TooManyWebhooks` exception
 * Adds necessary middleware to the webhook creation route to ensure oauth token is registered correctly with the api client
 * If a person has not yet configured `webhook-created-handler` correctly it'll fail before creating the webhook, preventing a webhook from actually being created unless there's a handler to go alongside it