### PR TITLE
Ignoring whitespace

### DIFF
--- a/src/Discord/Guild.php
+++ b/src/Discord/Guild.php
@@ -50,7 +50,7 @@ class Guild extends Fluent implements CanHavePermissions
         // because this is generated on the fly we'll cache it
         if ($this->abbreviationCache == null) {
             $firstLetters = '';
-            foreach (explode(' ', $this->name) as $word) {
+            foreach (explode(' ', trim($this->name)) as $word) {
                 $firstLetters .= $word[0];
             }
             $this->abbreviationCache = strtoupper($firstLetters);


### PR DESCRIPTION
If a guild name has a space before or after it, it's possible for an error to occur.  Adding a `trim()` means we'll never have whitespace on the end.

Example error:

![screen shot 2018-01-20 at 3 40 22 pm](https://user-images.githubusercontent.com/524933/35187820-4ef2d784-fdf8-11e7-974c-573befc91e7f.png)
