### PR TITLE
Added handler for erroring out when bot doesn't get added

### DIFF
--- a/src/Discord/Bots/HandlesBotAddedToGuild.php
+++ b/src/Discord/Bots/HandlesBotAddedToGuild.php
@@ -20,6 +20,12 @@ trait HandlesBotAddedToGuild
     abstract public function botAdded(string $accessToken, int $expiresIn, string $refreshToken, Guild $guild) : RedirectResponse;
 
     /**
+     * If the user hits cancel, we'll need to handle the error.  Usually
+     * $error = "access_denied"
+     */
+    abstract public function botNotAdded(string $error) : RedirectResponse;
+
+    /**
      * When an error occurs when adding a bot the exception will be passed here.
      *
      * For a list of common error scenarios you should handle,

--- a/src/Discord/Bots/HandlesBotAddedToGuild.php
+++ b/src/Discord/Bots/HandlesBotAddedToGuild.php
@@ -21,7 +21,7 @@ trait HandlesBotAddedToGuild
 
     /**
      * If the user hits cancel, we'll need to handle the error.  Usually
-     * $error = "access_denied"
+     * $error = "access_denied".
      */
     abstract public function botNotAdded(string $error) : RedirectResponse;
 

--- a/src/Http/BotCallback.php
+++ b/src/Http/BotCallback.php
@@ -26,6 +26,11 @@ class BotCallback
         /** @var HandlesBotAddedToGuild $botAddedHandler */
         $botAddedHandler = $application->make($config->get('laravel-restcord.bot-added-handler'));
 
+        // can happen if the user decides not to add our bot
+        if ($request->has('error')) {
+            return $botAddedHandler->botNotAdded($request->get('error'));
+        }
+
         try {
             $response = $client->post('https://discordapp.com/api/oauth2/token', [
                 'headers' => [

--- a/tests/Discord/Bots/HandlesBotsAddedToGuildTest.php
+++ b/tests/Discord/Bots/HandlesBotsAddedToGuildTest.php
@@ -43,4 +43,13 @@ class BotAddToGuildStub
     public function botAdded(Discord\Guild $Guild): RedirectResponse
     {
     }
+
+    /**
+     * If the user hits cancel, we'll need to handle the error.  Usually
+     * $error = "access_denied"
+     */
+    public function botNotAdded(string $error): RedirectResponse
+    {
+
+    }
 }

--- a/tests/Discord/Bots/HandlesBotsAddedToGuildTest.php
+++ b/tests/Discord/Bots/HandlesBotsAddedToGuildTest.php
@@ -46,10 +46,9 @@ class BotAddToGuildStub
 
     /**
      * If the user hits cancel, we'll need to handle the error.  Usually
-     * $error = "access_denied"
+     * $error = "access_denied".
      */
     public function botNotAdded(string $error): RedirectResponse
     {
-
     }
 }


### PR DESCRIPTION
Adding the ability to handle the scenario where the user didn't add the bot.  Most commonly this is when they hit "Cancel" and don't proceed adding the bot.