### PR TITLE
Update Guild.php

### DIFF
--- a/src/Discord/Guild.php
+++ b/src/Discord/Guild.php
@@ -51,7 +51,9 @@ class Guild extends Fluent implements CanHavePermissions
         if ($this->abbreviationCache == null) {
             $firstLetters = '';
             foreach (explode(' ', trim($this->name)) as $word) {
-                $firstLetters .= $word[0];
+                if (isset($word[0])) {
+                    $firstLetters .= $word[0];
+                }
             }
             $this->abbreviationCache = strtoupper($firstLetters);
         }


### PR DESCRIPTION
Despite the `trim()` somehow it's still possible to end up with a space at the end, or at least the error "Uninitialized string offset: 0" so we're just going to check and see if it's set.  This should resolve the issue.