### PR TITLE
Can now use different key/secrets for bot and web

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ composer require more-cores/laravel-restcord:2.*
 ]
 ```
 
+<a name="environment-variables" />
+
+## Environment Variables
+
+ * `DISCORD_BOT_KEY`
+ * `DISCORD_BOT_SECRET`
+ * `DISCORD_KEY`
+ * `DISCORD_SECRET`
+ 
+Bot key/secret will be used for callback endpoints related to adding a bot or creating a webhook as well as when the application is running in the console such as queue workers and cron. 
+
 <a name="usage" />
 
 # Usage

--- a/src/Discord.php
+++ b/src/Discord.php
@@ -15,6 +15,9 @@ class Discord
     public static $key;
 
     /** @var string */
+    public static $secret;
+
+    /** @var string */
     public static $callbackUrl;
 
     public function __construct(?ApiClient $apiClient = null)
@@ -64,6 +67,16 @@ class Discord
     public static function key() : string
     {
         return self::$key;
+    }
+
+    public static function setSecret(string $secret)
+    {
+        self::$secret = $secret;
+    }
+
+    public static function secret() : string
+    {
+        return self::$secret;
     }
 
     public static function setCallbackUrl(string $callbackUrl)

--- a/src/Http/BotCallback.php
+++ b/src/Http/BotCallback.php
@@ -38,8 +38,8 @@ class BotCallback
                 ],
                 'form_params' => [
                     'grant_type'    => 'authorization_code',
-                    'client_id'     => env('DISCORD_KEY'),
-                    'client_secret' => env('DISCORD_SECRET'),
+                    'client_id'     => Discord::key(),
+                    'client_secret' => Discord::secret(),
                     'code'          => $request->get('code'),
 
                     // this endpoint is never hit, it just needs to be here for OAuth compatibility

--- a/src/Http/WebhookCallback.php
+++ b/src/Http/WebhookCallback.php
@@ -33,8 +33,8 @@ class WebhookCallback
                 ],
                 'form_params' => [
                     'grant_type'    => 'authorization_code',
-                    'client_id'     => env('DISCORD_KEY'),
-                    'client_secret' => env('DISCORD_SECRET'),
+                    'client_id'     => Discord::key(),
+                    'client_secret' => Discord::secret(),
                     'code'          => $request->get('code'),
 
                     // this endpoint is never hit, it just needs to be here for OAuth compatibility

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -55,7 +55,14 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
      */
     public function register()
     {
-        Discord::setKey(env('DISCORD_KEY', ''));
+        // Allow the application to have separate key/secrets for web/console
+        if ($this->app->runningInConsole()) {
+            Discord::setKey(env('DISCORD_BOT_KEY', ''));
+            Discord::setSecret(env('DISCORD_BOT_SECRET', ''));
+        } else {
+            Discord::setKey(env('DISCORD_KEY', ''));
+            Discord::setSecret(env('DISCORD_SECRET', ''));
+        }
         Discord::setCallbackUrl(env('APP_URL', ''));
 
         // upon login add the token to session if using Discord's socialite

--- a/tests/Http/BotCallbackTest.php
+++ b/tests/Http/BotCallbackTest.php
@@ -79,14 +79,17 @@ class BotCallbackTest extends TestCase
         $response = Mockery::mock(Response::class);
         $response->shouldReceive('getBody')->andReturn($stream);
 
+        Discord::setKey($key = uniqid());
+        Discord::setSecret($secret = uniqid());
+
         $this->client->shouldReceive('post')->with('https://discordapp.com/api/oauth2/token', [
             'headers' => [
                 'Accept' => 'application/json',
             ],
             'form_params' => [
                 'grant_type'    => 'authorization_code',
-                'client_id'     => env('DISCORD_KEY'),
-                'client_secret' => env('DISCORD_SECRET'),
+                'client_id'     => $key,
+                'client_secret' => $secret,
                 'code'          => $code,
                 'redirect_uri'  => $url,
             ],

--- a/tests/Http/WebhookCallbackTest.php
+++ b/tests/Http/WebhookCallbackTest.php
@@ -75,14 +75,17 @@ class WebhookCallbackTest extends TestCase
         $response = Mockery::mock(Response::class);
         $response->shouldReceive('getBody')->andReturn($stream);
 
+        Discord::setKey($key = uniqid());
+        Discord::setSecret($secret = uniqid());
+
         $this->client->shouldReceive('post')->with('https://discordapp.com/api/oauth2/token', [
             'headers' => [
                 'Accept' => 'application/json',
             ],
             'form_params' => [
                 'grant_type'    => 'authorization_code',
-                'client_id'     => env('DISCORD_KEY'),
-                'client_secret' => env('DISCORD_SECRET'),
+                'client_id'     => $key,
+                'client_secret' => $secret,
                 'code'          => $code,
                 'redirect_uri'  => $url,
             ],


### PR DESCRIPTION
This PR enables us to use a different key/secret for when the application is running in console vs web mode.  This allows your web site and backend queue workers/cron to use separate rate limiting.