### PR TITLE
Update ServiceProvider.php

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -83,9 +83,6 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
             return new DiscordClient([
                 'token' => $config['bot-token'],
 
-                // use Laravel's monologger
-                'logger' => $app['log']->getMonolog(),
-
                 'throwOnRatelimit' => $config['throw-exception-on-rate-limit'],
             ]);
         });


### PR DESCRIPTION
Laravel 5.6 removed the monolog configuration, so this line needs to be removed for 5.6 compatibility.